### PR TITLE
feat: add launch at login setting

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,8 @@ let package = Package(
             linkerSettings: [
                 .linkedFramework("AppKit"),
                 .linkedFramework("ApplicationServices"),
-                .linkedFramework("Carbon")
+                .linkedFramework("Carbon"),
+                .linkedFramework("ServiceManagement")
             ]
         )
     ]

--- a/Sources/Viewport/AppDelegate.swift
+++ b/Sources/Viewport/AppDelegate.swift
@@ -7,6 +7,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     private let presetStore = ResizePresetStore()
     private let resizer = WindowResizer()
     private lazy var hotKeyManager = GlobalHotKeyManager(store: presetStore)
+    private let launchAtLoginManager = LaunchAtLoginManager()
     private var lastActiveApplication: NSRunningApplication?
     private var settingsWindowController: SettingsWindowController?
 
@@ -140,7 +141,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     @objc private func openSettings() {
         if settingsWindowController == nil {
-            settingsWindowController = SettingsWindowController(store: presetStore, hotKeyManager: hotKeyManager)
+            settingsWindowController = SettingsWindowController(store: presetStore, hotKeyManager: hotKeyManager, launchAtLoginManager: launchAtLoginManager)
         }
 
         promoteToRegular()

--- a/Sources/Viewport/LaunchAtLoginManager.swift
+++ b/Sources/Viewport/LaunchAtLoginManager.swift
@@ -1,0 +1,16 @@
+import ServiceManagement
+
+@MainActor
+final class LaunchAtLoginManager {
+    var isEnabled: Bool {
+        SMAppService.mainApp.status == .enabled
+    }
+
+    func setEnabled(_ enabled: Bool) throws {
+        if enabled {
+            try SMAppService.mainApp.register()
+        } else {
+            try SMAppService.mainApp.unregister()
+        }
+    }
+}

--- a/Sources/Viewport/SettingsWindowController.swift
+++ b/Sources/Viewport/SettingsWindowController.swift
@@ -4,13 +4,16 @@ import AppKit
 final class SettingsWindowController: NSWindowController {
     private let store: ResizePresetStore
     private let hotKeyManager: GlobalHotKeyManager
+    private let launchAtLoginManager: LaunchAtLoginManager
     private var presetCheckboxes: [(preset: ResizePreset, checkbox: NSButton)] = []
     private weak var shortcutRecorder: ShortcutRecorderView?
     private weak var shortcutErrorLabel: NSTextField?
+    private weak var launchAtLoginCheckbox: NSButton?
 
-    init(store: ResizePresetStore, hotKeyManager: GlobalHotKeyManager) {
+    init(store: ResizePresetStore, hotKeyManager: GlobalHotKeyManager, launchAtLoginManager: LaunchAtLoginManager) {
         self.store = store
         self.hotKeyManager = hotKeyManager
+        self.launchAtLoginManager = launchAtLoginManager
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 380, height: 340),
@@ -41,6 +44,7 @@ final class SettingsWindowController: NSWindowController {
         }
         shortcutRecorder?.setShortcut(store.applyLastPresetShortcut)
         updateShortcutErrorLabel()
+        launchAtLoginCheckbox?.state = launchAtLoginManager.isEnabled ? .on : .off
     }
 
     private func buildContent() {
@@ -68,6 +72,9 @@ final class SettingsWindowController: NSWindowController {
         let shortcutSection = buildShortcutSection()
         shortcutSection.translatesAutoresizingMaskIntoConstraints = false
 
+        let generalSection = buildGeneralSection()
+        generalSection.translatesAutoresizingMaskIntoConstraints = false
+
         let resetButton = NSButton(title: "Reset", target: self, action: #selector(resetToDefaults))
         resetButton.bezelStyle = .rounded
         resetButton.controlSize = .small
@@ -88,6 +95,7 @@ final class SettingsWindowController: NSWindowController {
 
         contentView.addSubview(presetStack)
         contentView.addSubview(shortcutSection)
+        contentView.addSubview(generalSection)
         contentView.addSubview(footer)
 
         NSLayoutConstraint.activate([
@@ -99,7 +107,11 @@ final class SettingsWindowController: NSWindowController {
             shortcutSection.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 22),
             shortcutSection.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -22),
 
-            footer.topAnchor.constraint(equalTo: shortcutSection.bottomAnchor, constant: 14),
+            generalSection.topAnchor.constraint(equalTo: shortcutSection.bottomAnchor, constant: 14),
+            generalSection.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 22),
+            generalSection.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -22),
+
+            footer.topAnchor.constraint(equalTo: generalSection.bottomAnchor, constant: 14),
             footer.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 22),
             footer.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -22),
             footer.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -14)
@@ -176,6 +188,34 @@ final class SettingsWindowController: NSWindowController {
         errorLabel.widthAnchor.constraint(equalTo: section.widthAnchor).isActive = true
 
         return section
+    }
+
+    private func buildGeneralSection() -> NSView {
+        let title = sectionTitleLabel("GENERAL")
+
+        let checkbox = NSButton(checkboxWithTitle: "Launch at Login", target: self, action: #selector(toggleLaunchAtLogin(_:)))
+        checkbox.state = launchAtLoginManager.isEnabled ? .on : .off
+        checkbox.translatesAutoresizingMaskIntoConstraints = false
+        launchAtLoginCheckbox = checkbox
+
+        let section = NSStackView(views: [title, checkbox])
+        section.orientation = .vertical
+        section.alignment = .leading
+        section.spacing = 6
+
+        return section
+    }
+
+    @objc private func toggleLaunchAtLogin(_ sender: NSButton) {
+        let enable = sender.state == .on
+        do {
+            try launchAtLoginManager.setEnabled(enable)
+        } catch {
+            sender.state = enable ? .off : .on
+            let alert = NSAlert(error: error)
+            alert.messageText = enable ? "Could Not Enable Launch at Login" : "Could Not Disable Launch at Login"
+            alert.runModal()
+        }
     }
 
     private func sectionTitleLabel(_ text: String) -> NSTextField {


### PR DESCRIPTION
## Summary

Adds a **Launch at Login** setting to the Settings window, letting users opt in to Viewport starting automatically at login.

> This PR was created with the assistance of [Claude](https://claude.ai).

## Changes

- `Sources/Viewport/LaunchAtLoginManager.swift` (new) — thin wrapper around `SMAppService.mainApp` with `isEnabled` and `setEnabled(_:)`
- `Package.swift` — links the `ServiceManagement` framework
- `Sources/Viewport/AppDelegate.swift` — instantiates `LaunchAtLoginManager` and passes it to `SettingsWindowController`
- `Sources/Viewport/SettingsWindowController.swift` — new "GENERAL" section with a "Launch at Login" checkbox; errors surface as `NSAlert` and the checkbox is reverted on failure

## Test Plan

- [ ] Build with `scripts/build-app.sh` and move `.build/Viewport.app` to `/Applications`
- [ ] Open Settings → verify "GENERAL" section appears with "Launch at Login" checkbox
- [ ] Check the box → confirm Viewport appears in **System Settings → General → Login Items**
- [ ] Uncheck → confirm it is removed from Login Items